### PR TITLE
DOCS (HTML) Renumber document

### DIFF
--- a/html.md
+++ b/html.md
@@ -1,42 +1,41 @@
 # HTML style guide
 
-Version 1.0
-Last updated: Wednesday 25 May 2016
+Version 1.1.0
+Last updated: Tuesday 5 July 2016
 
 The terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are used in this document with the meanings found in [RFC 2119: Key words for use in RFCs to indicate requirement levels](https://www.ietf.org/rfc/rfc2119.txt).
 
-<!-- MarkdownTOC -->
+<!-- MarkdownTOC depth=3 -->
 
 - [1. Syntax](#1-syntax)
-    - [General formatting](#general-formatting)
-    - [Accessibility](#accessibility)
-    - [Attribute order](#attribute-order)
-    - [Boolean attributes](#boolean-attributes)
-    - [Lean markup](#lean-markup)
-- [2. HTML5 doctype](#2-html5-doctype)
-- [3. Language attribute](#3-language-attribute)
-- [4. Character encoding and meta tags](#4-character-encoding-and-meta-tags)
-- [5. Page title](#5-page-title)
-- [6. IE compatibility](#6-ie-compatibility)
-- [7. Links to external CSS and JavaScript files](#7-links-to-external-css-and-javascript-files)
-    - [Do not use `type`](#do-not-use-type)
-- [8. Element rules](#8-element-rules)
-    - [Address](#address)
-    - [Bold and strong](#bold-and-strong)
-    - [Comments](#comments)
-    - [Forms](#forms)
-    - [Images](#images)
-        - [alt text](#alt-text)
-    - [Italics and emphasis](#italics-and-emphasis)
-    - [Lists](#lists)
-    - [Tables](#tables)
-    - [And the rest...](#and-the-rest)
-- [9. Class and ID names](#9-class-and-id-names)
-    - [Standard class names](#standard-class-names)
-    - [Microformats](#microformats)
-- [10. Avoid JavaScript-generated markup](#10-avoid-javascript-generated-markup)
-- [11. Error pages](#11-error-pages)
-    - [Error templates](#error-templates)
+    - [1.1 General formatting](#11-general-formatting)
+    - [1.2 Accessibility](#12-accessibility)
+    - [1.3 Attribute order](#13-attribute-order)
+    - [1.4 Boolean attributes](#14-boolean-attributes)
+    - [1.5 Lean markup](#15-lean-markup)
+- [2. Document head](#2-document-head)
+    - [2.1 HTML5 doctype](#21-html5-doctype)
+    - [2.2 Language attribute](#22-language-attribute)
+    - [2.3 Character encoding and meta tags](#23-character-encoding-and-meta-tags)
+    - [2.4 Page title](#24-page-title)
+    - [2.5 IE compatibility](#25-ie-compatibility)
+    - [2.6 Links to external CSS and JavaScript files](#26-links-to-external-css-and-javascript-files)
+- [3. Element rules](#3-element-rules)
+    - [3.1 Address](#31-address)
+    - [3.2 Bold and strong](#32-bold-and-strong)
+    - [3.3 Comments](#33-comments)
+    - [3.4 Forms](#34-forms)
+    - [3.5 Images](#35-images)
+    - [3.6 Italics and emphasis](#36-italics-and-emphasis)
+    - [3.7 Lists](#37-lists)
+    - [3.8 Tables](#38-tables)
+    - [3.9 tor.com/element-index/\) for advice on the best use of HTML5 elements.](#39-torcomelement-index-for-advice-on-the-best-use-of-html5-elements)
+- [4. Class and ID names](#4-class-and-id-names)
+    - [4.1 Standard class names](#41-standard-class-names)
+    - [4.2 Microformats](#42-microformats)
+- [5. Avoid JavaScript-generated markup](#5-avoid-javascript-generated-markup)
+- [6. Error pages](#6-error-pages)
+    - [6.1 Error templates](#61-error-templates)
 - [References](#references)
 
 <!-- /MarkdownTOC -->
@@ -46,7 +45,7 @@ The terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are used in this document 
 
 ## 1. Syntax 
 
-### General formatting
+### 1.1 General formatting
 
 As [@mdo](http://mdo.github.io/code-guide/) says in his code guide, "Strive to maintain HTML standards and semantics, but not at the expense of practicality. Use the least amount of markup with the fewest intricacies whenever possible."
 
@@ -57,12 +56,12 @@ As [@mdo](http://mdo.github.io/code-guide/) says in his code guide, "Strive to m
 * Do not include a trailing slash on self-closing elements, such as `<br>`, `<hr>`, `<img>`, `<link>` and `<meta>`. These are optional in the [HTML5 specification](http://dev.w3.org/html5/spec-author-view/syntax.html#syntax-start-tag).
 
 
-### Accessibility
+### 1.2 Accessibility
 * Do not set `tabindex` manually; rely on the browser to set the order.
 * Paragraphs of text SHOULD always be placed in a `<p>` tag. Never use multiple `<br>` tags.
 
 
-### Attribute order
+### 1.3 Attribute order
 
 HTML attributes SHOULD come in this particular order for easier reading of code.
 
@@ -76,7 +75,7 @@ HTML attributes SHOULD come in this particular order for easier reading of code.
 Classes make for great reusable components, so they come first; `id`s are more specific and SHOULD be used sparingly (e.g., for in-page bookmarks or JavaScript hooks), so they come second.
 
 
-### Boolean attributes
+### 1.4 Boolean attributes
 
 Unlike in XHTML, in HTML5 many attributes don't require a value to be set, like `disabled` or `checked`, so do not set them.
 
@@ -97,7 +96,7 @@ If you _must_ include the attribute's value (if you are using XHTML5, for instan
 For more information, read the latest [HTML5 specification](http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#boolean-attributes).
 
 
-### Lean markup
+### 1.5 Lean markup
 
 Whenever possible, avoid superfluous parent elements when writing HTML. Many times this requires iteration and refactoring, but produces less HTML. For example:
 
@@ -114,7 +113,9 @@ Whenever possible, avoid superfluous parent elements when writing HTML. Many tim
 
 
 
-## 2. HTML5 doctype 
+## 2. Document head
+
+### 2.1 HTML5 doctype 
 
 Use a doctype that triggers standards mode in your browser; this ensures more consistent rendering in browsers. Quirks mode MUST always be avoided.
 
@@ -125,9 +126,7 @@ For simplicity, use the HTML5 doctype:
 ```
 
 
-
-
-## 3. Language attribute
+### 2.2 Language attribute
 
 The HTML5 specification recommends specifying a language attribute on the root HTML element. This aids speech synthesis tools to determine what pronounciation to use, translation tools what rules to use, etc.
 
@@ -142,9 +141,7 @@ Sitepoint lists all [ISO two-letter language codes](http://www.sitepoint.com/web
 ```
 
 
-
-
-## 4. Character encoding and meta tags
+### 2.3 Character encoding and meta tags
 
 Ensure proper rendering of your content by declaring an explicit character encoding. When doing so, you may avoid using character entities in your HTML, provided their encoding matches that of the document, generally UTF-8 ([Unicode](http://unicode.org/)).
 
@@ -161,14 +158,12 @@ The character encoding MUST be the first element within `head` as this affects t
 
 These three `<meta>` elements (if used) MUST come before any other `<meta>`elements.
 
-Remember, `<meta>` tags SHOULD not include a self-closing trailing slash.
+Remember, in HTML5 `<meta>` tags SHOULD NOT include a self-closing trailing slash.
 
 A comprehensive list of `<meta>`, `<link>`, social media, and browser and platform-specific elements can be found on Josh Buchea's [HEAD GitHub repository](https://github.com/joshbuchea/HEAD).
 
 
-
-
-## 5. Page title
+### 2.4 Page title
 
 The standard format for the `<title> ... </title>` tag uses a pipe (`|`) character to separate the page name from the University name:
 
@@ -179,9 +174,7 @@ Page name | University of St Andrews
 Including the page name first makes it easier to create meaningful bookmarks, and improved SEO.
 
 
-
-
-## 6. IE compatibility
+### 2.5 IE compatibility
 
 Internet Explorer 8 and newer supports the use of a document compatibility <meta> tag to specify what version of IE the page should be rendered as.
 
@@ -199,16 +192,14 @@ As [Microsoft has withdrawn support for older versions of Internet Explorer](htt
 For more information, read this comprehensive [Stack Overflow article](http://stackoverflow.com/questions/6771258/whats-the-difference-if-meta-http-equiv-x-ua-compatible-content-ie-edge-e).
 
 
-
-
-## 7. Links to external CSS and JavaScript files
+### 2.6 Links to external CSS and JavaScript files
 
 Link to external CSS and JavaScript files so that the files may be cached by your browser, saving bandwidth.
 
 Do not embed `<style>` CSS or use inline JavaScript or `<script>` code (unless absolutely necessary).
 
 
-### Do not use `type`
+#### Do not use `type`
 
 In line with the HTML5 specification, there is no need to specify a `type` when including CSS and JavaScript files, as `text/css` and `text/javascript` are their respective defaults.
 
@@ -225,12 +216,12 @@ In line with the HTML5 specification, there is no need to specify a `type` when 
 
 
 
-## 8. Element rules
+## 3. Element rules
 
 Specific guidelines about certain HTML elements.
 
 
-### Address
+### 3.1 Address
 
 Do not use the `<address>` element. Despite having been around since HTML3 in 1995, it is invariably used the wrong way.
 
@@ -243,7 +234,7 @@ According to the [W3C HTML specification](http://w3c.github.io/html/sections.htm
 Rather than causing confusion, simply do not use it.
 
 
-### Bold and strong
+### 3.2 Bold and strong
 
 Remember that markup should be semantic: the elements used should also convey a layer of meaning. In HTML5:
 
@@ -251,7 +242,7 @@ Remember that markup should be semantic: the elements used should also convey a 
 * `<b>` indicates "a span of text to which attention is being drawn for utilitarian purposes without conveying any extra importance and with no implication of an alternate voice or mood, such as keywords in a document abstract, product names in a review, actionable words in interactive text-driven software, or an article lede." ([WhatWG](https://html.spec.whatwg.org/multipage/semantics.html#the-b-element))
 
 
-### Comments
+### 3.3 Comments
 
 Comments are your messages to other developers, as well as to yourself, if you come back to your code after several months working on something else.
 
@@ -270,7 +261,7 @@ Comments MAY make their way into production environments.
 Avoid writing closing tag comments, like `<!-- /.element -->`. This just adds to page load time. Plus, most editors have indentation guides and open/close tag highlighting.
 
 
-### Forms
+### 3.4 Forms
 
 * Lean towards radio or checkbox lists instead of select menus; the former are more accessible.
 * Wrap radio and checkbox inputs and their text in `<label>`s. No need for `for` attributes here: the wrapping automatically associates the two.
@@ -279,7 +270,7 @@ Avoid writing closing tag comments, like `<!-- /.element -->`. This just adds to
 * Input field placeholders are generally bad for accessibility. Do not hide text that would be useful to the user in a placeholder as it will disappear as soon as the user starts typing. For more guidance see [Placeholders in form fields are harmful](https://www.nngroup.com/articles/form-design-placeholders/).
 
 
-### Images
+### 3.5 Images
 
 * All images used in `<img>` elements MUST be in either GIF, JPG, PNG or SVG formats.
 * You MUST specify height and width attributes when using an `<img>` element. This improves page rendering speed as it allows the browser to understand the page layout without having to wait for the images to download to learn their dimensions.
@@ -296,7 +287,7 @@ All images MUST have `alt` attributes defined to describe the image. The descrip
 Do not use phases like "Image of..." or "Graphic of...". It should be clear from the context that this is an image.
 
 
-### Italics and emphasis
+### 3.6 Italics and emphasis
 
 Remember that markup SHOULD be semantic: the elements used SHOULD also convey a layer of meaning. In HTML5 
 
@@ -304,7 +295,7 @@ Remember that markup SHOULD be semantic: the elements used SHOULD also convey a 
 * `<i>` indicates "a span of text in an alternate voice or mood, or otherwise offset from the normal prose in a manner indicating a different quality of text, such as a taxonomic designation, a technical term, an idiomatic phrase from another language, transliteration, a thought, or a ship name in Western texts." ([WhatWG](https://html.spec.whatwg.org/multipage/semantics.html#the-i-element))
 
 
-### Lists
+### 3.7 Lists
 
 List items MUST always be within `<ul>`, `<ol>`, or `<dl>` elements. Never use a set of `<div>` or `<p>` tags.
 
@@ -327,7 +318,7 @@ Although in HTML5 you may omit closing tags from certain elements such as list i
 ```
 
 
-### Tables
+### 3.8 Tables
 
 Tables MUST only be used to present tabular data; they MUST NOT be used for presentation.
 
@@ -357,14 +348,12 @@ Make use of `<thead>`, `<tfoot>`, `<tbody>`, and `<th>` tags (and `scope` attrib
 ```
 
 
-### And the rest...
-
-If in doubt, check the HTML5 Doctor's [HTML5 Element Index](http://html5doctor.com/element-index/) for advice on the best use of HTML5 elements.
+### 3.9 tor.com/element-index/) for advice on the best use of HTML5 elements.
 
 
 
 
-## 9. Class and ID names
+## 4. Class and ID names
 
 Guidance on class and ID names can be found in the CSS style guide. Here are a few basics:
 
@@ -376,12 +365,12 @@ Guidance on class and ID names can be found in the CSS style guide. Here are a f
 * Separate multiple values in a class attribute with two spaces; this makes it much easier to read, e.g. `<button class="btn`  `btn-link">`.
 
 
-### Standard class names
+### 4.1 Standard class names
 
 Where possible prefer to use standard class names, for example when using [Bootstrap](http://getbootstrap.com/) components.
 
 
-### Microformats
+### 4.2 Microformats
 
 "Designed for humans first and machines second, microformats are a set of simple, open data formats built upon existing and widely adopted standards. Instead of throwing away what works today, microformats intend to solve simpler problems first by adapting to current behaviors and usage patterns."
 
@@ -396,7 +385,7 @@ For the following content types, consider using [Microformat 2](http://microform
 
 
 
-## 10. Avoid JavaScript-generated markup
+## 5. Avoid JavaScript-generated markup
 
 Unless you are using a JavaScript templating engine such as [Handlebars]](http://handlebarsjs.com/), do not 'hide' markup in JavaScript files. It makes content harder to find, harder to edit and diminishes performance.
 
@@ -410,7 +399,7 @@ See CSS style guide for more on JavaScript hooks.
 
 
 
-## 11. Error pages
+## 6. Error pages
 
 Error pages MUST be built such that they require no external dependency on anything whatsoever. That means static HTML with inline CSS and base64-encoded images.
 
@@ -422,7 +411,7 @@ The following are banned from every error page:
 * All `<img>` tags with a `src` pointing to a URL.
 
 
-### Error templates
+### 6.1 Error templates
 
 We use error pages for very specific purposes.
 


### PR DESCRIPTION
Combine sections 2 to 7 under a new section "Document head" to make document more easily scanable.
Update version number, and convert to semantic version.